### PR TITLE
Fix link for "Android Hive Tutorials"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 - [Android Design in Action Video series] (https://www.youtube.com/playlist?list=PLWz5rJ2EKKc8j2B95zGMb8muZvrIy-wcF) The video series by Android Design Team of Google.
 - [Android Design in Action slides] (https://play.google.com/store/apps/details?id=com.astuetz.android.adia&feature=md)- The application that gives you access to the slides of the video series.
 - [Android DevBytes Video Series] (https://www.youtube.com/playlist?list=PLWz5rJ2EKKc_XOgcRukSoKKjewFJZrKV0) - It is the technical counterpart of Android Design in Action series.
-- [Android Hive Tutorials] (www.androidhive.info) - Very good tutorials for beginners.
+- [Android Hive Tutorials](http://www.androidhive.info) - Very good tutorials for beginners.
 - [Android Weekly](http://androidweekly.net) - Newsletter with weekly information about android.
 - [Android Asset Studio](http://romannurik.github.io/AndroidAssetStudio/) - Generator for icons and other assets.
 - [Android Action Bar Style Generator](http://jgilfelt.github.io/android-actionbarstylegenerator/).


### PR DESCRIPTION
Hello,

If you tried to click on the link "Android Hive Tutorials" when reading the "readme.md" file on the Github interface the link would not work because the link would be pointing to the URL "https://github.com/JStumpp/awesome-android/blob/master/www.androidhive.info".
