### PR TITLE
Splunk MINT, Bugsnag and MaterialDrawer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 - [SlidingMenu](https://github.com/jfeinstein10/SlidingMenu) - Library to create applications with slide-in menus.
 - [PagerSlidingTabStrip](https://github.com/astuetz/PagerSlidingTabStrip) - An interactive indicator to navigate between the different pages of a ViewPager.
 - [Page View indicator](https://github.com/JakeWharton/Android-ViewPagerIndicator) - Support for horizontally scrolling ViewPager.
+- [MaterialDrawer](https://github.com/mikepenz/MaterialDrawer) - Simple take on a material design navigation drawer.
 
 #### Animations
 - [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids) - Library for using the Honeycomb animation API on all versions of the platform back to 1.0.
@@ -110,6 +111,8 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 
 - [Crashlytics](https://crashlytics.com) - Easy crash reporting solution.
 - [HockeyApp](http://hockeyapp.net) - Distribution, Crash Reports, Feedback and Analytics
+- [Splunk MINT](https://mint.splunk.com/) - Monitoring, Crash Reports, Real tima data, Statistic.
+- [Bugsnag](https://bugsnag.com/) - Cross platform error monitoring.
 
 ### Networking
 

--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,8 @@ My personal recommendation is (for now) to use the android api to build a native
 
 ### Kotlin
 - [Anko](https://github.com/JetBrains/anko) - DSL for Android written in Kotlin by JetBrains.
+- [Kotterknife](https://github.com/JakeWharton/kotterknife) - Android view injection writen in Kotlin based on ButterKnife
+- [Android Kotlin Samples](https://github.com/irontec/android-kotlin-samples) - Some basic Android code samples writen in Kotlin.
 
 # Other Awesome Lists
 Other amazingly awesome lists can be found in the [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness) list.


### PR DESCRIPTION
Added Splunk MINT and Bugsnag links for the Crash Monitoring tag and MaterialDrawer library for the Navigation tag.