### PR TITLE
added try-with-resource compatibility library to 'other' list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -340,6 +340,7 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 - [Android-Link-Preview](https://github.com/LeonardoCardoso/Android-Link-Preview) - It makes a preview from an url, grabbing all the information such as title, relevant texts and images.
 - [Sensey](https://github.com/nisrulz/sensey) - Detecting gestures in a snap.
 - [UserAwareVideoView](https://github.com/kevalpatel2106/UserAwareVideoView) - A customized video view that will automatically pause video is user is not looking at device screen!
+- [Try-with-resources Compatibility](https://github.com/prestongarno/trywithres-compat) - Standalone compile-time only dependency that backports try-with-resource statements to work with pre-API 19 devices
 
 ## Resources
 


### PR DESCRIPTION
This tool is for supporting any existing modules that are being held back from the Android Studio 2.4 previews because of their relying on retrolambda try-with-resource support.  This standalone library allows migrating from retrolambda and using the new Android Studio builds without having to change existing try-with-resource statements.