### PR TITLE
Add RecyclerTabLayout library to Navigation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 - [SlidingTutorial](https://github.com/Cleveroad/slidingtutorial-android) - Simple library that helps to create awesome sliding android app tutorials.
 - [PagerSlidingTabStrip](https://github.com/astuetz/PagerSlidingTabStrip) - An interactive indicator to navigate between the different pages of a ViewPager.
 - [Page View indicator](https://github.com/JakeWharton/ViewPagerIndicator) - Support for horizontally scrolling ViewPager.
+- [RecyclerTabLayout](https://github.com/nshmura/RecyclerTabLayout) - An efficient TabLayout library implemented with RecyclerView.
 - [MaterialDrawer](https://github.com/mikepenz/MaterialDrawer) - Simple take on a material design navigation drawer.
 - [Debug-Artist](https://github.com/baristaventures/debug-artist) - Debug menu to enable leakcanary, scalpel and others easy.
 - [Floating-Navigation-View](https://github.com/andremion/Floating-Navigation-View) - A simple Floating Action Button that shows an anchored Navigation View.


### PR DESCRIPTION
This PR adds a library I found recently that works really well for creating tab layouts. It's similar to the _PagerSlidingTabStrip_ and _Page View indicator_ libraries, but seems more up-to-date.