### PR TITLE
Add a reference to adb-enhanced

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -331,6 +331,7 @@ A curated list of awesome Android [libraries](#libraries) and [resources](#resou
 - [Stetho](https://github.com/facebook/stetho) - Debug hierarchy and network from chrome.
 - [Android Debug Database](https://github.com/amitshekhariitbhu/Android-Debug-Database) - Android Debug Database is a powerful library for debugging databases and shared preferences in Android applications.
 - [Android Debug Bridge - ADB](https://github.com/mzlogin/awesome-adb/blob/master/README.en.md) - a command-line tool to assist in debugging Android-powered devices
+- [ADB Enhanced](https://github.com/ashishb/adb-enhanced) - a command-line wrapper around ADB for developers, so that, developers don't have to remember esoteric version-dependent commands
 
 ### Wireless
 


### PR DESCRIPTION
Add a reference to adb-enhanced, a wrapper around ADB which allows rapid modification of the device settings during the app development process to test various configurations for example, low battery, screen rotation, doze mode etc. 

Disclosure: I created adb-enhanced