### PR TITLE
Add Teller library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -427,6 +427,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Flexbox Layout](https://github.com/google/flexbox-layout) - FlexboxLayout is a library which brings the similar capabilities of CSS Flexible Box Layout Module to Android. 
 - [Agile Boiler Plate](https://github.com/xresco/Android-Agile-Boiler-Plate) - The boiler plate is based on MVP architecture and it is fully based on Dependency Injection design pattern using Dagger2.
 - [Gradle buildSrcVersions](https://github.com/jmfayard/buildSrcVersions) - A kotlin dsl to simplify dependencies management
+- [Teller](https://github.com/levibostian/Teller-Android/) - Teller facilitates the downloading, saving, and reading of the cached data of your app. Keep your user's data fresh and remove those annoying loading screens!
 
 ## Resources
 


### PR DESCRIPTION
Add [Teller](https://github.com/levibostian/Teller-Android/) library. 

I built Teller to help me build offline-first mobile apps so I can remove annoying loading screens for my users. Cache data offline. 

This is great and all, but managing a cache is a pain. That is why I built Teller. 

* Remove annoying loading screens from your app.
* Do not worry about your user having a spotty Internet connection.
* Allow your users to complete tasks in your app, faster.
* Teller has performance improvements built-in to save your user's battery life.

...and some geeky features devs will appreciate. 
* Small - The only dependency at this time is RxJava2 (with a future update making this an optional dependency). 
* Built in Kotlin, for Kotlin (also compatible with Java)
* Not opinionated. Use any storage method you wish
* Paging just works
* Full test suite, full documentation website. 

Thank you for the consideration!