### PR TITLE
Add Sentry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Catcho](https://github.com/alhazmy13/Catcho) - No Force Close any more.
 - [Apteligent](https://www.apteligent.com/) - Cross platform crash reporting/analytics solution. Supports NDK log.
 - [Instabug](https://instabug.com/) - Bug reporting, Crash Reporting, In-app Feedback.
+- [Sentry](https://sentry.io/) - Sentry provides self-hosted and cloud-based error monitoring that helps all software teams discover, triage, and prioritize errors in real-time.
 
 ### Networking
 


### PR DESCRIPTION
Add Sentry to the Crash monitoring section.

Repo: https://github.com/getsentry/sentry-android

Why?
An easy to integrate and use Crash monitoring tool for Android with NDK support.