### PR TITLE
Adding PrimeCalendar into "Date & Time" category.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -401,6 +401,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [ThreeTen Android Backport](https://github.com/JakeWharton/ThreeTenABP) - An adaptation of the JSR-310 backport for Android.
 - [Joda-Time Android](https://github.com/dlew/joda-time-android) - Joda-Time library with Android specialization.
 - [True Time](https://github.com/instacart/truetime-android) - Android NTP time library. Get the true current time impervious to device clock time changes.
+- [PrimeCalendar](https://github.com/aminography/PrimeCalendar) - Provides all of the "java.util.Calendar" functionalities for Persian, Hijri, Japanese, etc, as well as their conversion to each other.
 
 ### Runtime Permissions
 


### PR DESCRIPTION
I've developed a calendar library in Kotlin language which can be used in Android/JVM apps. So, I like to introduce it to awesome-android.