### PR TITLE
Add Measure to crash monitoring

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Catcho](https://github.com/alhazmy13/Catcho) - No Force Close any more.
 - [Apteligent](https://www.apteligent.com/) - Cross platform crash reporting/analytics solution. Supports NDK log.
 - [Instabug](https://instabug.com/) - Bug reporting, Crash Reporting, In-app Feedback.
+- [Measure](https://github.com/measure-sh/measure/) - Open source tool to monitor crash, ANR, performance of mobile apps in production. It can be self-hosted.
 
 ### Networking
 


### PR DESCRIPTION
Add Measure to crash monitoring section

Repo: https://github.com/measure-sh/measure/

Why?
Measure is an open-source tool to monitor mobile apps. It captures crashes, ANRs, navigation events, API requests, and much more to create detailed session timelines that help quickly find the root cause of issues. It can be self hosted.