### PR TITLE
Add Android Nvim Plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,6 +362,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 ### Debugging Tools
 
 - [Linx](https://github.com/pedrovgs/Lynx) - Show logcat inside the device for debug builds
+- [Android Nvim Plugin](https://github.com/iamironz/android-nvim-plugin) - Neovim plugin for Android/Gradle build, deploy, and logcat.
 - [Scalpel](https://github.com/JakeWharton/scalpel) - View the entire hierarchy in 3d in the phone.
 - [Stetho](https://github.com/facebook/stetho) - Debug hierarchy and network from chrome.
 - [Android Debug Database](https://github.com/amitshekhariitbhu/Android-Debug-Database) - Android Debug Database is a powerful library for debugging databases and shared preferences in Android applications.


### PR DESCRIPTION
## Description

This PR adds [Android Nvim Plugin](https://github.com/iamironz/android-nvim-plugin), a Neovim plugin for Android/Gradle build, deploy, and logcat workflows.

## Why Android Nvim Plugin?

- Build and deploy Android apps via Gradle from Neovim
- Stream logcat in-editor for debugging
- Reduce context switching during Android development in Neovim

## Placement

Added under Libraries > Debugging Tools because it focuses on logcat and debugging workflows.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] The library/tool is actively maintained
- [x] The library/tool supports Android target
- [x] The library/tool has documentation/README