### PR TITLE
Add FireVision IPTV to Video section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [ijkplayer](https://github.com/Bilibili/ijkplayer) - Android/iOS video player based on FFmpeg n3.2, with MediaCodec, VideoToolbox support.
 - [Exoplayer](https://github.com/google/ExoPlayer) - ExoPlayer is an application level media player for Android, allow  playing audio and video both locally and over the Internet.
    Supports features like Dynamic adaptive streaming over HTTP (DASH), SmoothStreaming and Common Encryption
+- [FireVision IPTV](https://github.com/akshaynikhare/FireVisionIPTV) - Open-source IPTV player for Amazon FireTV with channel management, EPG support, and device pairing.
 - [VideoPlayView](https://github.com/MarcinMoskala/VideoPlayView) - Custom Android view with video player, play/stop, loader and placeholder image.
 
 #### Camera


### PR DESCRIPTION
## Description

Adding [FireVision IPTV](https://github.com/akshaynikhare/FireVisionIPTV) to the **Video** section.

FireVision IPTV is an open-source IPTV player for Amazon FireTV devices featuring:
- Channel management with M3U/IPTV support
- EPG (Electronic Programme Guide) integration  
- Device pairing with self-hosted FireVision IPTV Server
- Built natively for Fire TV/Android TV

MIT licensed, actively maintained (latest: v2.1.3).