### PR TITLE
Add SceneView — 3D & AR SDK for Jetpack Compose

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,8 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 
 ### Game Development
 
+- [SceneView](https://github.com/sceneview/sceneview) - 3D & AR SDK for Jetpack Compose. Filament rendering, ARCore integration, 26+ composable node types. Successor to Google Sceneform. [Open Source](https://github.com/sceneview/sceneview)
+
 - [Libgdx](https://libgdx.badlogicgames.com/) - Cross-platform game engine and SDK. [Open Source](https://github.com/libGDX/libGDX)
 - [Vuforia](https://www.vuforia.com/) - Augmented Reality library.
 - [Unity](https://unity3d.com/unity/features/multiplatform) - Cross-platform game creation system.


### PR DESCRIPTION
## What

Adds [SceneView](https://github.com/sceneview/sceneview) to the **Game Development** section.

## Why

SceneView is the only Compose-native 3D & AR library for Android:

- Jetpack Compose declarative API with 26+ composable node types
- Google Filament rendering engine (PBR, IBL, shadows)
- ARCore integration (plane detection, cloud anchors, face mesh)
- Successor to Google Sceneform (archived in 2021)
- ~5MB APK impact
- 1.2k+ GitHub stars, 350+ forks
- Used by Fortune 500 companies

[Maven Central](https://central.sonatype.com/artifact/io.github.sceneview/sceneview) | [npm (MCP)](https://www.npmjs.com/package/sceneview-mcp)