### PR TITLE
Add Ethora SDK for Android (Chat & Messaging)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -384,6 +384,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Build a one-on-one Android chat app using Kotlin](https://www.cometchat.com/tutorials/build-one-on-one-chat-in-your-android-app-using-kotlin/) - Build a one-one-one Android chat app in Kotlin within few minutes using CometChat Pro. This tutorial discusses the features such as login, getting list of contacts, user presence indicators, sending/receiving messages etc.
 - [Stream Chat](https://getstream.io/tutorials/android-chat/) - Comprehensive SDK & Components for real-time chat, powered by [Stream](https://getstream.io/chat/).
 - [Add Push Notifications to Your Android Chat App Using Kotlin](https://www.cometchat.com/tutorials/android-chat-push-notifications/) - Add push notifications in your Android chat apps in Kotlin with the help of CometChat Pro and Firebase Cloud Messaging (FCM).
+- [Ethora SDK for Android](https://github.com/dappros/ethora-sdk-android) - Native Kotlin/Jetpack Compose chat SDK with built-in AI agent / chatbot framework, JitPack-published, self-host or use Ethora Cloud.
 
 #### Custom Dialog
 


### PR DESCRIPTION
Adds [Ethora SDK for Android](https://github.com/dappros/ethora-sdk-android) under **Chat & Messaging**.

Native Kotlin / Jetpack Compose chat SDK for [Ethora](https://github.com/dappros/ethora), an open-source chat & messaging platform with a built-in AI agent / chatbot framework. Self-host the server or use the hosted Ethora Cloud.

- Repo: https://github.com/dappros/ethora-sdk-android (Apache-2.0)
- Install: JitPack — https://jitpack.io/#dappros/ethora-sdk-android (35 tagged releases through `v1.0.35`)
- Sample app: https://github.com/dappros/ethora-sample-android
- Format: `[package](link) - Description.` per CONTRIBUTING.