### PR TITLE
Add handsets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -369,6 +369,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [ADB Enhanced](https://github.com/ashishb/adb-enhanced) - a command-line wrapper around ADB for developers, so that, developers don't have to remember esoteric version-dependent commands
 - [Pidcat](https://github.com/JakeWharton/pidcat) - a colored command-line ADB wrapper that only shows log entries for a specific application package
 - [AppSpector](https://appspector.com) - Remote Android and iOS debugging and data collection service. You can debug networking, logs, SQLite and mock device's geo location.
+- [handsets](https://github.com/elliotgao2/handsets) - High-performance Android control CLI for agents and humans, with millisecond-level latency and no APK required.
 
 
 ### Wireless


### PR DESCRIPTION
Adds [handsets](https://github.com/elliotgao2/handsets) to the **Debugging Tools** section.

handsets is a high-performance Android control CLI in the same neighbourhood as the existing ADB / ADB Enhanced / Pidcat entries — it drives Android over `adb forward` from a host shell, no APK and no root required. The on-device daemon is a single jar (~few hundred KB) that runs under shell UID via `app_process`.

Why include it:

- Sub-7 ms wire-level latency per call (`hs bench`), with `node_click` defaulting to `AccessibilityNodeInfo.ACTION_CLICK` to bypass the Android InputDispatcher.
- `hs ui` outputs a flat verb-led table instead of an XML dump, which makes it readable both for humans grepping a screen and for LLM agents driving the device.
- CSS-like + Playwright-flavoured selectors (`:has-text`, `:below`, `:near`, …) for label-based lookups.
- Python bindings via `pip install handsets`.

License: MIT. Documentation at <https://elliotgao2.github.io/handsets/>.