### PR TITLE
Add Compose BOM changelog to Resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -471,7 +471,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Mindorks](https://mindorks.com/) - Become a complete and happy Android developer.
 - [AndroidVille](https://ayusch.com/) - Become a better Android Engineer. A website dedicated to Android Development covering advanced topics such as RxJava, Android Zygote and much more.
 - [Android Stack Weekly](https://blog.canopas.com/tagged/canopas-android-weekly) - A weekly newsletter on new development and updates of Android universe.
-- [Compose BOM](https://compose-bom.com) - Reference for Jetpack Compose Bill of Materials versions and their corresponding library versions.
+- [Compose BOM changelog](https://compose-bom.com) - Reference for Jetpack Compose Bill of Materials versions and their corresponding library versions.
 
 ### Code examples
 - [Android Architecture Blueprints](https://github.com/android/architecture-samples) - The Android Architecture Blueprints project demonstrates strategies to help solve or avoid common android problems.

--- a/readme.md
+++ b/readme.md
@@ -471,6 +471,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Mindorks](https://mindorks.com/) - Become a complete and happy Android developer.
 - [AndroidVille](https://ayusch.com/) - Become a better Android Engineer. A website dedicated to Android Development covering advanced topics such as RxJava, Android Zygote and much more.
 - [Android Stack Weekly](https://blog.canopas.com/tagged/canopas-android-weekly) - A weekly newsletter on new development and updates of Android universe.
+- [Compose BOM](https://compose-bom.com) - Reference for Jetpack Compose Bill of Materials versions and their corresponding library versions.
 
 ### Code examples
 - [Android Architecture Blueprints](https://github.com/android/architecture-samples) - The Android Architecture Blueprints project demonstrates strategies to help solve or avoid common android problems.


### PR DESCRIPTION
## What is it?

**compose-bom.com** is an open-source, static community tool that diffs any two
Jetpack Compose BOM versions and aggregates the underlying library release notes.

- Select "from" and "to" BOM versions → see exactly what changed
- Per-library cards showing old → new version and full release notes
- "Show unchanged" toggle to focus on what actually moved
- No backend, no account — fully static, instant

Example: https://compose-bom.com/?from=2026.03.01&to=2026.05.00
Source: https://github.com/keymusicman/compose-bom-changelog

## Why include it?

compose-bom.com fills a gap Google's official docs don't cover: there's no
changelog for the Compose BOM itself, so developers have to cross-reference each
library manually when evaluating an upgrade. This tool does that in one click.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/47a02805-87be-4b4f-a416-807b1dc85197" />
