### PR TITLE
Add Google Play Screenshot Sizes 2026 reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -471,6 +471,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Mindorks](https://mindorks.com/) - Become a complete and happy Android developer.
 - [AndroidVille](https://ayusch.com/) - Become a better Android Engineer. A website dedicated to Android Development covering advanced topics such as RxJava, Android Zygote and much more.
 - [Android Stack Weekly](https://blog.canopas.com/tagged/canopas-android-weekly) - A weekly newsletter on new development and updates of Android universe.
+- [Google Play Screenshot Sizes 2026](https://shotlingo.com/tools/app-store-screenshot-sizes) - Reference for every Google Play screenshot size (phone, 7" / 10" tablet, Wear OS, Android TV) alongside the iOS equivalents — sortable, copy-to-clipboard pixel values, JSON / CSV download.
 
 ### Code examples
 - [Android Architecture Blueprints](https://github.com/android/architecture-samples) - The Android Architecture Blueprints project demonstrates strategies to help solve or avoid common android problems.


### PR DESCRIPTION
Adds a free reference under **Resources** (near the Device Art Generator entry).

[Google Play Screenshot Sizes 2026](https://shotlingo.com/tools/app-store-screenshot-sizes) is a single-page reference covering every current Google Play screenshot dimension (phone, 7" / 10" tablet, Wear OS, Android TV) alongside the iOS equivalents.

Features:
- Copy-to-clipboard chips on every pixel value
- Per-class min/max side and aspect rules from Play Console
- Downloadable JSON / CSV spec pack for build scripts
- "Last verified" stamp + canonical source URL per row
- Embeddable iframe widget

Single-line addition, no promotional copy. Happy to move it elsewhere.