### PR TITLE
Add WarpLink to Cloud Services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 ### Cloud Services
 
 - [CloudRail](https://cloudrail.com) - Unified API Library for: Cloud Storage, Social Profiles, Payment, Email, SMS & POIs.
+- [WarpLink](https://github.com/WarpLinkApp/warplink-android-sdk) - Deep linking, deferred deep links, and install attribution with real-time analytics.
 
 ### Data binding
 


### PR DESCRIPTION
Adds [WarpLink](https://github.com/WarpLinkApp/warplink-android-sdk) under **Cloud Services**.

`WarpLink` is an open-source (MIT) Android SDK for deep linking, deferred deep links, and install attribution with real-time analytics. It ships on Maven Central (v1.0.x), has a documented README, and fits alongside CloudRail as a cloud-service SDK.

- Individual PR, single suggestion
- Format: `[package](link) - Description.`
- Searched existing entries, no duplicate