### PR TITLE
Add ShipSentry to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 
 - [libsignal-protocol-java](https://github.com/signalapp/libsignal-protocol-java) - A ratcheting forward secrecy protocol that works in synchronous and asynchronous messaging environments.
 - [Themis](https://github.com/cossacklabs/themis) - Multi-language framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.
+- [ShipSentry](https://github.com/adamglin0/shipsentry) - Local-first, zero-dependency scanner for common Android release configuration and source risks.
 
 ### GUI
 


### PR DESCRIPTION
Adds ShipSentry to the Security section.

ShipSentry is a documented, zero-dependency scanner for common Android release configuration and source risks. It runs locally without uploading source code, includes a reproducible sample project/report, and its regression suite passes on Ubuntu and macOS.

Project: https://github.com/adamglin0/shipsentry
CI: https://github.com/adamglin0/shipsentry/actions/workflows/test.yml
Sample report: https://adamglin0.github.io/shipsentry/report.html