### PR TITLE
Add Google Play & App Store Character Limits reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -471,6 +471,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Mindorks](https://mindorks.com/) - Become a complete and happy Android developer.
 - [AndroidVille](https://ayusch.com/) - Become a better Android Engineer. A website dedicated to Android Development covering advanced topics such as RxJava, Android Zygote and much more.
 - [Android Stack Weekly](https://blog.canopas.com/tagged/canopas-android-weekly) - A weekly newsletter on new development and updates of Android universe.
+- [Google Play & App Store Character Limits](https://shotlingo.com/tools/app-store-character-limits) - Searchable reference for every Play Console & App Store Connect metadata field character limit (title, short/full description, keywords), which fields Google actually indexes for search, and ASO tips per field. Free, no signup, JSON/CSV export.
 
 ### Code examples
 - [Android Architecture Blueprints](https://github.com/android/architecture-samples) - The Android Architecture Blueprints project demonstrates strategies to help solve or avoid common android problems.


### PR DESCRIPTION
## What this adds

A new entry in the **Resources** section, alongside the existing Device Art Generator / Android Asset Studio marketing-tool links:

> **[Google Play & App Store Character Limits](https://shotlingo.com/tools/app-store-character-limits)** — Searchable reference for every Play Console & App Store Connect metadata field character limit (title, short/full description, keywords), which fields Google actually indexes for search, and ASO tips per field. Free, no signup, JSON/CSV export.

## Why it fits

- Complements the existing "Device Art Generator" / asset-studio resources in the same section — this covers the metadata/copy side of a Play Store listing rather than the visual side.
- Free, no account required.
- Data-driven: JSON/CSV export for use in CI checklists.

Thanks for maintaining such a useful list — happy to tweak wording/placement if it doesn't fit your conventions.