### PR TITLE
Add Ghost in the Droid to Testing section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Roboletric](http://robolectric.org/) - Unit test framework to run tests inside the JVM on your workstation, not in the emulator.
 - [AssertJ Android](https://github.com/square/assertj-android) - AssertJ assertions geared towards Android.
 - [Green Coffee](https://github.com/mauriciotogneri/green-coffee) - Run your Cucumber tests in your Android instrumentation tests.
+- [Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) - Python MCP server with 62 tools for AI agent control of real Android and iOS devices via ADB and WebDriverAgent. `pip install ghost-in-the-droid`
 
 ### Tracking
 


### PR DESCRIPTION
## Summary

- Adds [Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) to the **Testing** section
- Ghost in the Droid is a Python MCP server with 62 tools for AI agent control of real Android and iOS devices via ADB and WebDriverAgent
- Install: `pip install ghost-in-the-droid`

## Why it fits here

Ghost in the Droid enables AI agents to directly control Android (and iOS) devices through MCP tools wrapping ADB and WebDriverAgent. It's a modern, AI-native approach to device automation that complements existing testing tools in this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)