### PR TITLE
Add OTP Board (OTP forwarder Android client)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [android-remote-notifications](https://github.com/kaiwinter/android-remote-notifications) - Pulls notifications from a remote JSON file and shows them in your app.
 - [Android HeartBeat Fixer](https://github.com/joaopedronardari/AndroidHeartBeatFixer) - Way to set heartbeat interval and users receive PushNotifications from GCM.
 
+- [OTP Board](https://github.com/TOBYCAI/otp-board) - Android client that listens for SMS and system notifications, extracts OTP/verification codes, and forwards them over HTTPS to a self-hosted dashboard. Written in Kotlin.
 ### Database
 - [Cupboard](https://bitbucket.org/littlerobots/cupboard) - Access the sqlite easily via direct database access or through the ContentProvider framework.
 - [DbInspector](https://github.com/infinum/android_dbinspector) - Provides a simple way to view the contents of the in-app database for debugging purposes.


### PR DESCRIPTION
### Added
- **OTP Board** — Android client that listens for SMS and system notifications, extracts OTP/verification codes, and forwards them over HTTPS to a self-hosted dashboard. Written in Kotlin.

### Category
`Libraries` → `Notifications` (notification listening / forwarding client)

### Details
- License: MIT
- Source: https://github.com/TOBYCAI/otp-board
- Kotlin + Jetpack, listens for SMS and notifications (WeChat, WhatsApp, email, etc.)
- Pairs with a self-hosted Node.js dashboard (admin console / WebAuthn biometric login / external notifications)
- Privacy: all extraction and forwarding stays between your device and your self-hosted server — no third-party cloud involved. A new "Security & Privacy" section in the README documents the data flow (on-device extraction, only the code is forwarded, original messages are never sent or stored).

符合 contributing.md 要求：开源（MIT）、提供链接与简短描述。
