### PR TITLE
Add Optics Framework (self-healing Appium test automation) to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Roboletric](http://robolectric.org/) - Unit test framework to run tests inside the JVM on your workstation, not in the emulator.
 - [AssertJ Android](https://github.com/square/assertj-android) - AssertJ assertions geared towards Android.
 - [Green Coffee](https://github.com/mauriciotogneri/green-coffee) - Run your Cucumber tests in your Android instrumentation tests.
+- [Optics Framework](https://github.com/mozarkai/optics-framework) - Self-healing test automation for Android apps via Appium; keyword-driven CSV/YAML tests with locator fallback across XPath, text, OCR and image strategies.
 
 ### Tracking
 


### PR DESCRIPTION
Adds [Optics Framework](https://github.com/mozarkai/optics-framework) to **Testing**.

**Why it should be included:** it brings something the current entries don't have — self-healing locators. When a UI locator breaks, optics falls back across XPath, visible text, OCR and image strategies instead of failing the run. Tests are keyword-driven CSV/YAML data executed over Appium, so they need no Java/Kotlin code, and it also covers Android TV platform profiles (Tizen/webOS too).

- Apache-2.0, actively maintained, documented: https://mozarkai.github.io/optics-framework/
- Format followed: `- [package](link) - Description.` ending with a period.
- Individual PR for one suggestion; no duplicate found in Testing section.