### PR TITLE
Add Phonebook to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Roboletric](http://robolectric.org/) - Unit test framework to run tests inside the JVM on your workstation, not in the emulator.
 - [AssertJ Android](https://github.com/square/assertj-android) - AssertJ assertions geared towards Android.
 - [Green Coffee](https://github.com/mauriciotogneri/green-coffee) - Run your Cucumber tests in your Android instrumentation tests.
+- [Phonebook](https://github.com/stag-build/phonebook) - Turns the `@Preview` composables already in your app into a browsable, self-hosted gallery of screenshots.
 
 ### Tracking
 


### PR DESCRIPTION
Adds [Phonebook](https://github.com/stag-build/phonebook) under **Testing**.

**What it is:** an open-source CLI that renders the `@Preview` composables already in an app — via Roborazzi + ComposablePreviewScanner on the JVM, so no emulator — and harvests them into a self-hosted, browsable HTML gallery. Designers and PMs can review UI states without installing Android Studio or a debug build.

**Why include it:** the existing Testing entries cover writing and running tests; this covers seeing the output. There's no free, self-hosted option in this space today — the comparable tools are paid snapshot SaaS.

- MIT licensed, no SaaS account, runs locally or in CI
- Live demo gallery: https://stag-build.github.io/phonebook/
- Write-up: https://medium.com/@orelzion/phonebook-a-storybook-style-preview-gallery-for-swiftui-and-compose-built-for-agents-e3e3f7c0a59a

One line added, following the existing format with a trailing period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)