### PR TITLE
Add Liquid-Glass-Android to GUI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [YuanaItemSettingView](https://github.com/andhikayuana/YuanaItemSettingView) - Customizable Item Setting View for Android.
 - [Gradients](https://github.com/bakhtiyork/gradients) - A curated collection of splendid gradients.
 - [OneAdapter](https://github.com/ironSource/OneAdapter) - RecyclerView Adapter with multiple modules and hooks to simplify and enhance the use while preventing common mistakes.
+- [Liquid-Glass-Android](https://github.com/QWEA0/Liquid-Glass-Android) - iOS 26 style Liquid Glass for the Android View system: SDF refraction, chromatic dispersion and sensor-driven specular highlights in a FrameLayout, API 24+.
 
 #### Paginate
 - [NoPaginate](https://github.com/NoNews/NoPaginate) - Simple Android pagination library


### PR DESCRIPTION
Adds [Liquid-Glass-Android](https://github.com/QWEA0/Liquid-Glass-Android) under **Libraries → GUI**.

Why: it is a Liquid Glass / glassmorphism component for the classic Android View system (a `FrameLayout` subclass that drops into existing XML layouts). The other Android Liquid Glass libraries target Jetpack Compose only, so there was no View-system option in the list. Real-time backdrop blur, SDF refraction, chromatic dispersion and sensor-driven specular; AGSL pipeline on API 33+ with a C++/NEON fallback down to API 24. MIT licensed, documented, published on JitPack with a demo APK.