### PR TITLE
Add measure.sh to crash monitoring category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -267,6 +267,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 - [Catcho](https://github.com/alhazmy13/Catcho) - No Force Close any more.
 - [Apteligent](https://www.apteligent.com/) - Cross platform crash reporting/analytics solution. Supports NDK log.
 - [Instabug](https://instabug.com/) - Bug reporting, Crash Reporting, In-app Feedback.
+- [Measure](https://measure.sh) - Helps mobile teams to monitor and fix crashes, ANRs, bugs, and performance issues. The open source alternative to Firebase Crashlytics.
 
 ### Networking
 


### PR DESCRIPTION
This PR adds [measure.sh](https://measure.sh) under the "Crash monitoring" category.

## About Measure

- **Website**: https://measure.sh
- **GitHub**: https://github.com/measure-sh/measure
- **Description**: Measure helps mobile teams monitor and fix crashes, ANRs, bugs, and performance issues. The open source alternative to Firebase Crashlytics.
- **License**: Apache 2
- **100% Open Source**
- **GitHub Stars**: 1.4K ⭐ (1,390 to be exact)
- **[Native Android SDK](https://staging.measure.sh/docs/getting-started/android)**

---

I've fully read the Contribution guidelines & followed strict adherance.