### PR TITLE
Add Callro to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ Awesome-Android is an amazing list for people who need a certain feature on thei
 
 - [libsignal-protocol-java](https://github.com/signalapp/libsignal-protocol-java) - A ratcheting forward secrecy protocol that works in synchronous and asynchronous messaging environments.
 - [Themis](https://github.com/cossacklabs/themis) - Multi-language framework for making typical encryption schemes easy to use: data at rest, authenticated data exchange, transport protection, authentication, and so on.
+- [Callro](https://getcallro.com) - Privacy-first, on-device spam and scam call blocker for Android that operates with zero contact-book harvesting. ([Google Play](https://play.google.com/store/apps/details?id=com.vindication.callro))
 
 ### GUI
 


### PR DESCRIPTION
### Summary
Adding Callro to the Security section.

- **Website:** https://getcallro.com
- **Google Play:** https://play.google.com/store/apps/details?id=com.vindication.callro
- **Reason:** Callro is a privacy-first, on-device spam and scam call blocker for Android that operates with zero contact-book harvesting or audio data sharing.